### PR TITLE
add gpu requirement to job requirements

### DIFF
--- a/examples/cifar10_tensorflow/launcher.py
+++ b/examples/cifar10_tensorflow/launcher.py
@@ -69,7 +69,10 @@ def main(_):
       experiment.add(
           xm.Job(
               executable=executable,
-              executor=xm_local.Vertex(tensorboard=tensorboard_capability),
+              executor=xm_local.Vertex(
+                tensorboard=tensorboard_capability,
+                requirements=xm.JobRequirements(T4=1)
+              ),
               args=hyperparameters,
           ))
 


### PR DESCRIPTION
without a gpu, this job will fail on cuda init. adding this to request a t4.  let me know if a hardware-agnostic solution is desired instead.