### PR TITLE
Fix Issue 57: Add support for L4 GPUs in Vertex jobs

### DIFF
--- a/xmanager/cloud/vertex.py
+++ b/xmanager/cloud/vertex.py
@@ -298,7 +298,11 @@ def get_machine_spec(job: xm.Job) -> Dict[str, Any]:
   for resource, value in requirements.task_requirements.items():
     accelerator_type = None
     if resource in xm.GpuType:
-      accelerator_type = 'NVIDIA_TESLA_' + str(resource).upper()
+      # TODO(b/289373107): Remove this special case.
+      if resource == xm.GpuType.L4_24TH:
+        accelerator_type = 'NVIDIA_L4'
+      else:
+        accelerator_type = 'NVIDIA_TESLA_' + str(resource).upper()
     elif resource in xm.TpuType:
       accelerator_type = _CLOUD_TPU_ACCELERATOR_TYPES[resource]
     if accelerator_type:

--- a/xmanager/cloud/vertex_test.py
+++ b/xmanager/cloud/vertex_test.py
@@ -155,6 +155,24 @@ class VertexTest(unittest.TestCase):
         },
     )
 
+  def test_get_machine_spec_l4(self):
+    job = xm.Job(
+        executable=local_executables.GoogleContainerRegistryImage('name', ''),
+        executor=local_executors.Vertex(
+            requirements=xm.JobRequirements(l4_24th=2)
+        ),
+        args={},
+    )
+    machine_spec = vertex.get_machine_spec(job)
+    self.assertDictEqual(
+        machine_spec,
+        {
+            'machine_type': 'g2-standard-4',
+            'accelerator_type': vertex.aip_v1.AcceleratorType.NVIDIA_L4,
+            'accelerator_count': 2,
+        },
+    )
+
   def test_get_machine_spec_tpu(self):
     job = xm.Job(
         executable=local_executables.GoogleContainerRegistryImage('name', ''),


### PR DESCRIPTION
This PR resolves issue #57 by adding support for L4 GPUs when launching jobs on Vertex AI.

**Description**
Currently, attempting to use an L4 GPU by specifying L4_24TH in `xm.JobRequirements` results in a KeyError: 'NVIDIA_TESLA_L4_24TH'. This is because the accelerator type was being constructed by prefixing the resource name with NVIDIA_TESLA_, which is not the correct identifier for L4 GPUs on Vertex AI. The correct accelerator type is NVIDIA_L4.

This change updates `vertex.py` to special-case the L4_24TH GPU type and use the correct NVIDIA_L4 accelerator name. A corresponding unit test has been added to `vertex_test.py` to verify the fix and prevent future regressions.

Changes
Modified `vertex.py` to correctly handle the L4 GPU accelerator type.
Added test_get_machine_spec_l4 to `vertex_test.py` to ensure L4 GPUs are correctly configured