### PR TITLE
Fix `ResourceType.architecture()`

### DIFF
--- a/xmanager/xm/resources.py
+++ b/xmanager/xm/resources.py
@@ -96,6 +96,31 @@ class ResourceType(enum.Enum, metaclass=_CaseInsensitiveResourceTypeMeta):
   def __str__(self):
     return self._name_
 
+  def architecture(self) -> 'Architecture':
+    """Returns the default host CPU architecture for this accelerator.
+
+    Accelerators backed by NVIDIA Grace superchips (e.g. GB200/GB300) are
+    hosted on ARM CPUs; other accelerators with a fixed host architecture
+    default to HASWELL (x86).
+
+    Raises:
+      ValueError: If this resource is not an accelerator or its host
+        architecture depends on the local machine.
+    """
+    if self not in AcceleratorType or self == ResourceType.LOCAL_GPU:
+      raise ValueError(f'{self} does not have a default architecture.')
+    if self in _ARM_HOSTED_ACCELERATORS:
+      return Architecture.ARM
+    return Architecture.HASWELL
+
+
+# Accelerators hosted on ARM CPUs. Defined at module scope (rather than as a
+# class attribute) to avoid being interpreted as an enum member.
+_ARM_HOSTED_ACCELERATORS = frozenset({
+    ResourceType.GB200,
+    ResourceType.GB300,
+})
+
 
 class _CaseInsensitiveServiceTierMeta(enum.EnumMeta):
   """Metaclass which allows case-insensitive enum lookup.
@@ -418,18 +443,15 @@ class JobRequirements:
     """Validates that the architecture is compatible with the accelerator."""
     if self.architecture is None or self.accelerator is None:
       return
-    if self.architecture != self.accelerator.architecture():
-      if (
-          self.architecture == Architecture.ARM  # GLP is supported on ARM
-          and self.accelerator == ResourceType.GLP
-      ):
-        return
-      else:
-        raise ValueError(
-            f'Accelerator {self.accelerator} requires architecture'
-            f' {self.accelerator.architecture()}, but {self.architecture} was'
-            ' specified.'
-        )
+    try:
+      accelerator_architecture = self.accelerator.architecture()
+    except ValueError:
+      return
+    if self.architecture != accelerator_architecture:
+      raise ValueError(
+          f'Accelerator {self.accelerator} requires architecture'
+          f' {accelerator_architecture}, but {self.architecture} was specified.'
+      )
 
   def _validate_accelerator_topology(self):
     """Validates that the topology is compatible with the accelerator."""

--- a/xmanager/xm/resources_test.py
+++ b/xmanager/xm/resources_test.py
@@ -147,6 +147,39 @@ class JobRequirementsTest(parameterized.TestCase):
         architecture,
     )
 
+  @parameterized.parameters(
+      (xm.ResourceType.P100, xm.Architecture.HASWELL),
+      (xm.ResourceType.TPU_V3, xm.Architecture.HASWELL),
+      (xm.ResourceType.GB200, xm.Architecture.ARM),
+      (xm.ResourceType.GB300, xm.Architecture.ARM),
+  )
+  def test_resource_type_architecture(self, accelerator, architecture):
+    self.assertEqual(accelerator.architecture(), architecture)
+
+  @parameterized.parameters(
+      xm.ResourceType.CPU,
+      xm.ResourceType.LOCAL_GPU,
+  )
+  def test_resource_type_without_default_architecture(self, resource):
+    with self.assertRaisesRegex(
+        ValueError, 'does not have a default architecture'
+    ):
+      resource.architecture()
+
+  @parameterized.parameters(
+      xm.Architecture.HASWELL,
+      xm.Architecture.ARM,
+  )
+  def test_local_gpu_accepts_explicit_architecture(self, architecture):
+    requirements = resources.JobRequirements(
+        local_gpu=1, architecture=architecture
+    )
+    self.assertEqual(requirements.architecture, architecture)
+
+  def test_local_gpu_has_no_inferred_architecture(self):
+    requirements = resources.JobRequirements(local_gpu=1)
+    self.assertIsNone(requirements.architecture)
+
   @parameterized.parameters([
       (xm.Architecture.ARM, xm.ResourceType.P100, True),
       (xm.Architecture.ARM, xm.ResourceType.GB200, False),


### PR DESCRIPTION
`JobRequirements` calls `ResourceType.architecture()`, but the public `ResourceType` enum does not currently implement it, causing accelerator requirements to fail with an `AttributeError`.

This PR:

- Adds default host architecture handling for accelerators.
- Maps `GB{200,300}` to `Architecture.ARM` and fixed-host. accelerators to `Architecture.HASWELL`
- Leaves `LOCAL_GPU` architecture unspecified unless provided explicitly.
- Adds regression coverage for inference and validation.