### PR TITLE
Exclude `name` from the `ExecutableSpec` field copy

### DIFF
--- a/xmanager/xm_cloud/experiment.py
+++ b/xmanager/xm_cloud/experiment.py
@@ -726,7 +726,7 @@ def _convert_xm_job_to_ess_job(
         ),
     )
 
-  explicit_executable_fields = {'resources', 'docker_image', 'args', 'env_vars'}
+  explicit_executable_fields = {'resources', 'docker_image', 'args', 'env_vars', 'name'}
   executable_proto_kwargs = {}
   for field in work_unit_pb2.ExecutableSpec.DESCRIPTOR.fields:
     if field.name in explicit_executable_fields:


### PR DESCRIPTION
`_convert_xm_job_to_ess_job` fills `ExecutableSpec` by setting four fields explicitly and copying every remaining field off `job.executable` by matching field names. `ExecutableSpec` has a `name` field and `xm.Executable` has a `name` attribute, so an executable's build-target label is copied into `ExecutableSpec.name`. That label is legal in Bazel and not in the RFC 1123 DNS label the server requires, so every work unit submitted through `xm_cloud` is rejected:

```
work_unit.executable.jobset.jobs.spec.name must be a valid DNS label
```

The sibling loop for `KubernetesJob` already lists `name` among its explicit fields for the same reason, so this makes the two consistent.

Reproduced against XMC `0.3.0` with a Bazel-packaged executable, where the generated name contains underscores.