### PR TITLE
Fix argument escaping for direct `argv` backends

### DIFF
--- a/examples/cifar10_torch/launcher.py
+++ b/examples/cifar10_torch/launcher.py
@@ -58,8 +58,8 @@ async def main(_):
                     # TODO: replace workerpool0 with the actual
                     # name of the job when Vertex AI supports custom name worker
                     # pools.
-                    'master_addr_port': xm.ShellSafeArg(
-                        utils.get_workerpool_address('workerpool0')
+                    'master_addr_port': utils.get_workerpool_address(
+                        'workerpool0'
                     ),
                 },
             ),

--- a/xmanager/cloud/build_image.py
+++ b/xmanager/cloud/build_image.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 """Builds images for XManager Docker executables."""
 
+import json
 import os
 import shutil
 import tempfile
@@ -297,9 +298,8 @@ def _create_entrypoint(py_executable: xm.PythonContainer) -> str:
 def _create_entrypoint_cmd(args: xm.SequentialArgs) -> str:
   """Create the entrypoint command with optional args."""
   entrypoint_args = ['./entrypoint.sh']
-  entrypoint_args.extend(args.to_list(utils.ARG_ESCAPER))
-  entrypoint = ', '.join([f'"{arg}"' for arg in entrypoint_args])
-  return f'ENTRYPOINT [{entrypoint}]'
+  entrypoint_args.extend(args.to_list(utils.ARGV_ESCAPER))
+  return f'ENTRYPOINT {json.dumps(entrypoint_args)}'
 
 
 def _wrap_late_bindings(destination: str, path: str, dockerfile: str) -> None:

--- a/xmanager/cloud/build_image_test.py
+++ b/xmanager/cloud/build_image_test.py
@@ -11,6 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import json
+
 from absl.testing import absltest
 from xmanager import xm
 from xmanager.cloud import build_image
@@ -50,6 +52,23 @@ class BuildImageTest(absltest.TestCase):
     project = self.create_container(xm.CommandList(commands))
     entrypoint_commands = build_image._get_entrypoint_commands(project)
     self.assertEndsWith(entrypoint_commands, ' \'$@\' "$@"')
+
+  def test_create_entrypoint_cmd_preserves_argv(self):
+    args = xm.SequentialArgs.from_collection({
+        'config': '{"key": 4}',
+        'path': 'a path',
+    })
+
+    instruction = build_image._create_entrypoint_cmd(args)
+
+    self.assertEqual(
+        json.loads(instruction.removeprefix('ENTRYPOINT ')),
+        [
+            './entrypoint.sh',
+            '--config={"key": 4}',
+            '--path=a path',
+        ],
+    )
 
 
 if __name__ == '__main__':

--- a/xmanager/cloud/kubernetes.py
+++ b/xmanager/cloud/kubernetes.py
@@ -106,7 +106,7 @@ class Client:
           image=executable.image_path,
           resources=requirements_from_executor(executor),  # pyrefly: ignore[bad-argument-type]
           args=xm.merge_args(executable.args, job.args).to_list(
-              utils.ARG_ESCAPER
+              utils.ARGV_ESCAPER
           ),
           env=env,
       )

--- a/xmanager/cloud/kubernetes_test.py
+++ b/xmanager/cloud/kubernetes_test.py
@@ -67,7 +67,7 @@ class KubernetesTest(parameterized.TestCase):
         executor=local_executors.Kubernetes(
             xm.JobRequirements(cpu=1, ram=1, t4=2)
         ),
-        args={'b': 2, 'c': 3},
+        args={'b': 2, 'c': '{"d": 4}'},
     )
     expected_service = k8s_client.V1Service(
         metadata=k8s_client.V1ObjectMeta(name='experiments'),
@@ -100,7 +100,11 @@ class KubernetesTest(parameterized.TestCase):
                                     'nvidia.com/gpu': '2',
                                 },
                             ),
-                            args=['--a=1', '--b=2', '--c=3'],
+                            args=[
+                                '--a=1',
+                                '--b=2',
+                                '--c={"d": 4}',
+                            ],
                             env=[],
                         )
                     ],

--- a/xmanager/cloud/vertex.py
+++ b/xmanager/cloud/vertex.py
@@ -182,7 +182,9 @@ class Client:
             )
         )
 
-      args = xm.merge_args(executable.args, job.args).to_list(utils.ARG_ESCAPER)
+      args = xm.merge_args(executable.args, job.args).to_list(
+          utils.ARGV_ESCAPER
+      )
       env_vars = {**executable.env_vars, **job.env_vars}
       env = [{'name': k, 'value': v} for k, v in env_vars.items()]
       if i == 0 and job.executor.requirements.replicas > 1:  # pyrefly: ignore[missing-attribute]

--- a/xmanager/cloud/vertex_test.py
+++ b/xmanager/cloud/vertex_test.py
@@ -51,7 +51,7 @@ class VertexTest(parameterized.TestCase):
             args=xm.SequentialArgs.from_collection({'a': 1}),
         ),
         executor=local_executors.Vertex(xm.JobRequirements(cpu=1, ram=1, t4=2)),
-        args={'b': 2, 'c': 3},
+        args={'b': 2, 'c': '{"d": 4}'},
     )
 
     expected_call = {
@@ -69,7 +69,11 @@ class VertexTest(parameterized.TestCase):
                         replica_count=1,
                         container_spec=aip_v1.ContainerSpec(
                             image_uri='image-path',
-                            args=['--a=1', '--b=2', '--c=3'],
+                            args=[
+                                '--a=1',
+                                '--b=2',
+                                '--c={"d": 4}',
+                            ],
                         ),
                     )
                 ],

--- a/xmanager/xm/job_blocks.py
+++ b/xmanager/xm/job_blocks.py
@@ -184,15 +184,16 @@ class SequentialArgs:
 
   def to_list(
       self,
-      escaper: Callable[[Any], str] = utils.ARGV_ESCAPER,
+      escaper: Callable[[Any], str] = utils.ARG_ESCAPER,
       kwargs_joiner: Callable[[str, str], str] = utils.trivial_kwargs_joiner,
   ) -> List[str]:
     """Exports items as a list ready to be passed into the command line.
 
     Args:
-      escaper: Serializes a single value into a token. The default suits a
-        backend that passes the tokens on as `argv`; a caller that joins them
-        into a command string for a shell must pass `utils.ARG_ESCAPER`.
+      escaper: Serializes a single value into a token. The default quotes the
+        token for a POSIX shell, which suits a caller joining the tokens into
+        a command string. A backend that hands the tokens over as `argv` must
+        pass `utils.ARGV_ESCAPER`.
       kwargs_joiner: Combines the name and the value of a keyword argument.
 
     Returns:

--- a/xmanager/xm/job_blocks.py
+++ b/xmanager/xm/job_blocks.py
@@ -184,10 +184,20 @@ class SequentialArgs:
 
   def to_list(
       self,
-      escaper: Callable[[Any], str] = utils.ARG_ESCAPER,
+      escaper: Callable[[Any], str] = utils.ARGV_ESCAPER,
       kwargs_joiner: Callable[[str, str], str] = utils.trivial_kwargs_joiner,
   ) -> List[str]:
-    """Exports items as a list ready to be passed into the command line."""
+    """Exports items as a list ready to be passed into the command line.
+
+    Args:
+      escaper: Serializes a single value into a token. The default suits a
+        backend that passes the tokens on as `argv`; a caller that joins them
+        into a command string for a shell must pass `utils.ARG_ESCAPER`.
+      kwargs_joiner: Combines the name and the value of a keyword argument.
+
+    Returns:
+      The sought list.
+    """
 
     def export_keyword_item(
         item: SequentialArgs._KeywordItem,

--- a/xmanager/xm/job_blocks_test.py
+++ b/xmanager/xm/job_blocks_test.py
@@ -99,6 +99,11 @@ class JobBlocksTest(unittest.TestCase):
 
     self.assertEqual(args.to_list(str), ['--pass_me=None'])
 
+  def test_to_list_default_escaper_quotes_for_a_shell(self):
+    args = job_blocks.SequentialArgs.from_collection({'config': '{"d": 4}'})
+
+    self.assertEqual(args.to_list(), ['--config=\'{"d": 4}\''])
+
   def test_json_serialize(self):
     args = job_blocks.SequentialArgs.from_collection({
         'a': 1,

--- a/xmanager/xm/utils.py
+++ b/xmanager/xm/utils.py
@@ -44,11 +44,13 @@ class SpecialArg(abc.ABC):
 
 @attr.s(auto_attribs=True)
 class ShellSafeArg(SpecialArg):
-  """Command line argument that shouldn't be escaped.
+  """Command line argument that shouldn't be quoted.
 
-  Normally all arguments would be passed to the binary as is. To let shell
-  substitutions (such as environment variable expansion) to happen the argument
-  must be wrapped with this structure.
+  Backends that run the job through a shell quote every argument, which
+  suppresses substitutions such as environment variable expansion. Wrapping an
+  argument in this structure exempts it from that quoting. Backends that hand
+  arguments over as `argv` neither quote nor substitute, so there the wrapper
+  makes no difference.
   """
 
   arg: str
@@ -60,14 +62,24 @@ class ShellSafeArg(SpecialArg):
     )
 
 
-def ARG_ESCAPER(value: Any) -> str:  # pylint: disable=invalid-name
+def ARGV_ESCAPER(value: Any) -> str:  # pylint: disable=invalid-name
+  """Serializes a value into an `argv` token for a backend with no shell."""
   match value:
     case ShellSafeArg():
       return value.arg
     case enum.Enum():
-      return shlex.quote(str(value.name))
+      return str(value.name)
     case _:
-      return shlex.quote(str(value))
+      return str(value)
+
+
+def ARG_ESCAPER(value: Any) -> str:  # pylint: disable=invalid-name
+  """Serializes a value into a token of a command destined for a POSIX shell."""
+  match value:
+    case ShellSafeArg():
+      return value.arg
+    case _:
+      return shlex.quote(ARGV_ESCAPER(value))
 
 
 def trivial_kwargs_joiner(key: str, value: str) -> str:

--- a/xmanager/xm/utils_test.py
+++ b/xmanager/xm/utils_test.py
@@ -43,6 +43,12 @@ class UtilsTest(unittest.TestCase):
     self.assertEqual(utils.ARG_ESCAPER('Jonny Droptable'), "'Jonny Droptable'")
     self.assertEqual(utils.ARG_ESCAPER(ResourceType.VESPEN), 'VESPEN')
 
+  def test_argv_escaper(self):
+    self.assertEqual(utils.ARGV_ESCAPER(1.0), '1.0')
+    self.assertEqual(utils.ARGV_ESCAPER('Jonny Droptable'), 'Jonny Droptable')
+    self.assertEqual(utils.ARGV_ESCAPER(ResourceType.VESPEN), 'VESPEN')
+    self.assertEqual(utils.ARGV_ESCAPER(utils.ShellSafeArg('$USER')), '$USER')
+
   def test_shell_safe_arg_in_f_string(self):
     # ShellSafeArg shouldn't be used in f-strings.
     with self.assertRaises(RuntimeError):

--- a/xmanager/xm_local/execution.py
+++ b/xmanager/xm_local/execution.py
@@ -16,6 +16,7 @@
 import asyncio
 import atexit
 import os
+import shlex
 import subprocess
 import threading
 from typing import Callable, List, cast
@@ -61,7 +62,7 @@ async def _launch_loaded_container_image(
           'No NVIDIA devices detected. Only NVIDIA GPUs are currently supported'
       ) from exception
 
-  args = xm.merge_args(executable.args, job.args).to_list(utils.ARG_ESCAPER)
+  args = xm.merge_args(executable.args, job.args).to_list(utils.ARGV_ESCAPER)
   env_vars = {**executable.env_vars, **job.env_vars}
   options = executor.docker_options or executors.DockerOptions()
 
@@ -129,7 +130,7 @@ async def _launch_local_binary(
         executable.command, args, env_vars, get_full_job_name(job.name)  # pyrefly: ignore[bad-argument-type]
     )
   else:
-    command = ' '.join([executable.command] + args)
+    command = ' '.join([shlex.quote(executable.command)] + args)
     process = await asyncio.create_subprocess_shell(
         cmd=command,
         env=env_vars,

--- a/xmanager/xm_local/execution_test.py
+++ b/xmanager/xm_local/execution_test.py
@@ -40,7 +40,7 @@ def create_test_job(
       executable=local_executables.LoadedContainerImage(
           name='test',
           image_id='test-image',
-          args=xm.SequentialArgs.from_collection({'a': 1}),
+          args=xm.SequentialArgs.from_collection({'a': 'with space'}),
           env_vars={'c': '0'},
       ),
       executor=local_executors.Local(
@@ -108,7 +108,7 @@ class ExecutionTest(unittest.IsolatedAsyncioTestCase, parameterized.TestCase):
         name='test-job',
         image_id='test-image',
         network='xmanager',
-        args=['--a=1'],
+        args=['--a=with space'],
         env_vars={'c': '0'},
         ports={8080: 8080},
         volumes=(
@@ -167,7 +167,7 @@ class ExecutionTest(unittest.IsolatedAsyncioTestCase, parameterized.TestCase):
         network='xmanager',
         detach=True,
         remove=True,
-        command=['--a=1'],
+        command=['--a=with space'],
         environment={'c': '0'},
         ports={8080: 8080},
         volumes=(
@@ -279,7 +279,7 @@ class ExecutionTest(unittest.IsolatedAsyncioTestCase, parameterized.TestCase):
           name='test-job',
           image_id='test-image',
           network='xmanager',
-          args=['--a=1'],
+          args=['--a=with space'],
           env_vars={'c': '0'},
           ports={8080: 8080},
           volumes={
@@ -308,6 +308,29 @@ class ExecutionTest(unittest.IsolatedAsyncioTestCase, parameterized.TestCase):
     self.assertIsInstance(handle, local_handles.BinaryHandle)
     await handle.wait()
     self.assertEqual(handle.name, 'test-job')
+    self.assertEqual(handle.process.returncode, 0)
+    stdout_reader = cast(asyncio.StreamReader, handle.process.stdout)
+    self.assertEqual(await stdout_reader.read(), b'--arg=with space\n')
+
+  async def test_launch_local_binary_with_space_in_command(self):
+    command = os.path.join(self.create_tempdir().full_path, 'test echo')
+    with open(command, 'w') as file:
+      file.write('#!/bin/sh\necho "$@"\n')
+    os.chmod(command, 0o755)
+    job = xm.Job(
+        name='test-job',
+        executable=local_executables.LocalBinary(
+            name='test_echo',
+            command=command,
+            args=xm.SequentialArgs.from_collection({'arg': 'with space'}),
+        ),
+        executor=local_executors.Local(experimental_stream_output=True),
+    )
+    handles = await execution.launch(
+        lambda x: x, job_group=xm.JobGroup(test_job=job)
+    )
+    handle = cast(local_handles.BinaryHandle, handles[0])
+    await handle.wait()
     self.assertEqual(handle.process.returncode, 0)
     stdout_reader = cast(asyncio.StreamReader, handle.process.stdout)
     self.assertEqual(await stdout_reader.read(), b'--arg=with space\n')

--- a/xmanager/xm_local/multiplexer.py
+++ b/xmanager/xm_local/multiplexer.py
@@ -3,6 +3,7 @@
 import asyncio
 import functools
 import logging
+import shlex
 import shutil
 import subprocess
 
@@ -17,16 +18,27 @@ def _has_tmux() -> bool:
 def _get_executable_command(
     executable_path: str, args: list[str], env_vars: dict[str, str]
 ) -> str:
-  """Builds a command to run the given executable with args and envs."""
-  env_as_list = [f'{k}={v}' for k, v in env_vars.items()]
-  launch_command = subprocess.list2cmdline(
-      [*env_as_list, executable_path, *args]
+  """Builds a command to run the given executable with args and envs.
+
+  Args:
+    executable_path: Path to the executable, quoted here.
+    args: Arguments already serialized as shell tokens, e.g. through
+      `xm.utils.ARG_ESCAPER`. They are not quoted here, so that an
+      `xm.ShellSafeArg` among them keeps its meaning.
+    env_vars: Environment variables, prepended as assignments and quoted here.
+
+  Returns:
+    A command for a POSIX shell.
+  """
+  env_as_list = [f'{k}={shlex.quote(v)}' for k, v in env_vars.items()]
+  launch_command = ' '.join(
+      [*env_as_list, shlex.quote(executable_path), *args]
   )
   # When the command is done, echo the command so it can be copy-pasted, and
   # then drop into a shell.
   command = (
-      f'{launch_command}; '
-      f'echo; echo Job completed.; echo {launch_command}; exec $SHELL'
+      f'{launch_command}; echo; echo Job completed.;'
+      f' echo {shlex.quote(launch_command)}; exec $SHELL'
   )
   return command
 
@@ -52,7 +64,7 @@ class Multiplexer:
 
     while True:
       process = await asyncio.create_subprocess_shell(
-          subprocess.list2cmdline([
+          shlex.join([
               'tmux',
               'new-session',
               '-d',
@@ -109,7 +121,7 @@ class Multiplexer:
       process = await self._new_session(inner_command, full_job_name)
     else:
       process = await asyncio.create_subprocess_shell(
-          subprocess.list2cmdline([
+          shlex.join([
               'tmux',
               'new-window',
               '-t',

--- a/xmanager/xm_local/multiplexer_test.py
+++ b/xmanager/xm_local/multiplexer_test.py
@@ -1,0 +1,121 @@
+"""Tests for xmanager.xm_local.multiplexer."""
+
+import json
+import os
+import shlex
+import subprocess
+import sys
+import unittest
+from unittest import mock
+
+from absl import flags
+from xmanager import xm
+from xmanager.xm import utils
+from xmanager.xm_local import multiplexer
+
+_SCRIPT = (
+    'import json, os, sys; '
+    'print(json.dumps([sys.argv[1], os.environ["TEST_VALUE"]]))'
+)
+_EXPECTED_OUTPUT = ['{"d": 4}', 'with space']
+
+
+def _executable_command() -> str:
+  """Builds a command whose argument and environment both need quoting."""
+  args = xm.SequentialArgs.from_collection([
+      '-c',
+      _SCRIPT,
+      '{"d": 4}',
+  ]).to_list(utils.ARG_ESCAPER)
+  return multiplexer._get_executable_command(
+      sys.executable,
+      args,
+      {'TEST_VALUE': 'with space'},
+  )
+
+
+def _run(command: str) -> subprocess.CompletedProcess:
+  return subprocess.run(
+      command,
+      shell=True,
+      check=True,
+      capture_output=True,
+      text=True,
+      # An empty `SHELL` turns the trailing `exec $SHELL` into a no-op, so the
+      # command terminates instead of waiting for an interactive shell.
+      env={**os.environ, 'SHELL': ''},
+  )
+
+
+class MultiplexerTest(unittest.IsolatedAsyncioTestCase):
+
+  def setUp(self):
+    super().setUp()
+    if not flags.FLAGS.is_parsed():
+      flags.FLAGS.mark_as_parsed()
+
+  def test_get_executable_command_preserves_arguments_and_environment(self):
+    result = _run(_executable_command())
+
+    self.assertEqual(
+        json.loads(result.stdout.splitlines()[0]), _EXPECTED_OUTPUT
+    )
+
+  def test_get_executable_command_echoes_a_reusable_command(self):
+    result = _run(_executable_command())
+
+    echoed_command = result.stdout.splitlines()[-1]
+    rerun = _run(echoed_command)
+    self.assertEqual(
+        json.loads(rerun.stdout.splitlines()[0]), _EXPECTED_OUTPUT
+    )
+
+  @mock.patch.object(multiplexer, '_has_tmux', return_value=True)
+  @mock.patch.object(multiplexer.asyncio, 'create_subprocess_shell')
+  async def test_new_session_quotes_tmux_arguments(
+      self, create_subprocess_shell, unused_has_tmux
+  ):
+    process = mock.AsyncMock()
+    process.wait.return_value = 0
+    create_subprocess_shell.return_value = process
+    tmux = multiplexer.Multiplexer()
+
+    await tmux._new_session("printf '%s\\n' 'a b'", 'job with space')
+
+    command = create_subprocess_shell.call_args.args[0]
+    self.assertEqual(
+        shlex.split(command),
+        [
+            'tmux',
+            'new-session',
+            '-d',
+            '-s',
+            'xm_0',
+            '-n',
+            'job with space',
+            "printf '%s\\n' 'a b'",
+        ],
+    )
+
+  @mock.patch.object(multiplexer, '_has_tmux', return_value=True)
+  @mock.patch.object(multiplexer.asyncio, 'create_subprocess_shell')
+  async def test_add_quotes_tmux_arguments_of_a_further_window(
+      self, create_subprocess_shell, unused_has_tmux
+  ):
+    process = mock.AsyncMock()
+    process.wait.return_value = 0
+    create_subprocess_shell.return_value = process
+    tmux = multiplexer.Multiplexer()
+    await tmux.add('/bin/echo', [], {}, 'first job')
+
+    await tmux.add('/bin/echo', [], {}, 'job with space')
+
+    command = create_subprocess_shell.call_args.args[0]
+    self.assertEqual(
+        shlex.split(command)[:6],
+        ['tmux', 'new-window', '-t', 'xm_0', '-n', 'job with space'],
+    )
+
+
+if __name__ == '__main__':
+  unittest.main()


### PR DESCRIPTION
Direct `argv` backends receive the POSIX shell quoting produced by `ARG_ESCAPER` as literal argument data. This one adds `ARGV_ESCAPER` for local Docker, `Vertex`, `Kubernetes`, and exec-form Docker `ENTRYPOINT` arguments while preserving `ARG_ESCAPER` for commands interpreted by a shell.

It also replaces `subprocess.list2cmdline` with POSIX quoting in the `tmux` path and serializes Docker `ENTRYPOINT` arguments through `json.dumps`. The tests cover JSON values across the direct-`argv`, shell, `tmux`, and `ENTRYPOINT` boundaries.

Fixes #75.