### PR TITLE
Quote bare `$@` in container entrypoints

### DIFF
--- a/docs/executable_specs.md
+++ b/docs/executable_specs.md
@@ -137,7 +137,7 @@ command as well as the Docker instructions.
 xm.PythonContainer(
     entrypoint=xm.CommandList([
       './pre_process.sh',
-      'python3 -m cifar10 $@',
+      'python3 -m cifar10 "$@"',
       './post_process.sh',
     ]),
     docker_instructions=[
@@ -158,8 +158,9 @@ python3 -m cifar10 fixed_arg1 fixed_arg2
 ./post_process.sh
 ```
 
-IMPORTANT: Note the use of `$@` which accepts command-line arguments. Otherwise,
-all command-line arguments are ignored by your entrypoint.
+IMPORTANT: Note the use of `"$@"` which accepts command-line arguments.
+Otherwise, all command-line arguments are ignored by your entrypoint. Quote it,
+since a bare `$@` splits every argument on whitespace.
 
 `xm.python_container` is a shortener for packageable construction.
 

--- a/xmanager/cloud/build_image.py
+++ b/xmanager/cloud/build_image.py
@@ -14,6 +14,7 @@
 """Builds images for XManager Docker executables."""
 
 import os
+import re
 import shutil
 import tempfile
 from typing import Dict, List, Optional
@@ -60,6 +61,8 @@ fi
 
 {cmds}
 """
+
+_BARE_ARGS_SUFFIX = re.compile(r'(^|\s)\$@$')
 
 
 def build(
@@ -277,7 +280,9 @@ def _get_entrypoint_commands(py_executable: xm.PythonContainer) -> str:
     )
   cmds = '\n'.join(cmds)
   # Allow passing extra parameters to the commands.
-  if not cmds.endswith(('$@', '"$@"')):
+  if _BARE_ARGS_SUFFIX.search(cmds):
+    cmds = _BARE_ARGS_SUFFIX.sub(r'\1"$@"', cmds)
+  elif not cmds.endswith('"$@"'):
     cmds = cmds + ' "$@"'
   return cmds
 

--- a/xmanager/cloud/build_image.py
+++ b/xmanager/cloud/build_image.py
@@ -62,7 +62,7 @@ fi
 {cmds}
 """
 
-_BARE_ARGS_SUFFIX = re.compile(r'(^|\s)\$@$')
+_BARE_ARGS_SUFFIX = re.compile(r'\$@$', re.MULTILINE)
 
 
 def build(
@@ -281,7 +281,7 @@ def _get_entrypoint_commands(py_executable: xm.PythonContainer) -> str:
   cmds = '\n'.join(cmds)
   # Allow passing extra parameters to the commands.
   if _BARE_ARGS_SUFFIX.search(cmds):
-    cmds = _BARE_ARGS_SUFFIX.sub(r'\1"$@"', cmds)
+    cmds = _BARE_ARGS_SUFFIX.sub('"$@"', cmds)
   elif not cmds.endswith('"$@"'):
     cmds = cmds + ' "$@"'
   return cmds

--- a/xmanager/cloud/build_image_test.py
+++ b/xmanager/cloud/build_image_test.py
@@ -39,6 +39,25 @@ class BuildImageTest(absltest.TestCase):
     self.assertEndsWith(entrypoint_commands, ' "$@"')
     self.assertNotEndsWith(entrypoint_commands, ' $@ "$@"')
 
+  def test_get_entrypoint_commands_quotes_unspaced_suffix(self):
+    commands = ['echo "aaa"$@']
+    project = self.create_container(xm.CommandList(commands))
+    entrypoint_commands = build_image._get_entrypoint_commands(project)
+    self.assertEndsWith(entrypoint_commands, 'echo "aaa""$@"')
+
+  def test_get_entrypoint_commands_quotes_suffix_of_an_inner_command(self):
+    commands = [
+        './pre_process.sh',
+        'python3 -m cifar10 $@',
+        './post_process.sh',
+    ]
+    project = self.create_container(xm.CommandList(commands))
+    entrypoint_commands = build_image._get_entrypoint_commands(project)
+    self.assertEqual(
+        entrypoint_commands,
+        './pre_process.sh\npython3 -m cifar10 "$@"\n./post_process.sh',
+    )
+
   def test_get_entrypoint_commands_no_dup_quoted_suffix(self):
     commands = ['echo "aaa" "$@"']
     project = self.create_container(xm.CommandList(commands))

--- a/xmanager/cloud/build_image_test.py
+++ b/xmanager/cloud/build_image_test.py
@@ -32,11 +32,12 @@ class BuildImageTest(absltest.TestCase):
     entrypoint_commands = build_image._get_entrypoint_commands(project)
     self.assertEndsWith(entrypoint_commands, ' "$@"')
 
-  def test_get_entrypoint_commands_no_dup_plain_suffix(self):
+  def test_get_entrypoint_commands_quotes_plain_suffix(self):
     commands = ['echo "aaa" $@']
     project = self.create_container(xm.CommandList(commands))
     entrypoint_commands = build_image._get_entrypoint_commands(project)
-    self.assertEndsWith(entrypoint_commands, ' $@')
+    self.assertEndsWith(entrypoint_commands, ' "$@"')
+    self.assertNotEndsWith(entrypoint_commands, ' $@ "$@"')
 
   def test_get_entrypoint_commands_no_dup_quoted_suffix(self):
     commands = ['echo "aaa" "$@"']

--- a/xmanager/cloud/data/wrapped_entrypoint.sh
+++ b/xmanager/cloud/data/wrapped_entrypoint.sh
@@ -16,5 +16,8 @@
 
 python3 -c "import vertex_utils; vertex_utils.create_workerpool_address_env_vars_script('./map_xm_env_vars')"
 source ./map_xm_env_vars
-ARGS=($(python3 -c "import vertex_utils; import sys; vertex_utils.print_workerpool_address_args(sys.argv)" $@ | tr -d '[],'))
-./entrypoint.sh ${ARGS[@]}
+ARGS=()
+while IFS= read -r ARG; do
+  ARGS+=("$ARG")
+done < <(python3 -c "import vertex_utils; import sys; vertex_utils.print_workerpool_address_args(sys.argv)" "$@")
+./entrypoint.sh "${ARGS[@]}"

--- a/xmanager/cloud/utils_test.py
+++ b/xmanager/cloud/utils_test.py
@@ -13,7 +13,12 @@
 # limitations under the License.
 """Tests for xmanager.cloud.utils."""
 
+import json
 import os
+import shlex
+import shutil
+import subprocess
+import sys
 import tempfile
 import unittest
 
@@ -34,6 +39,45 @@ _CLUSTER_SPEC = """{
 }""".replace(
     '\n', ' '
 )
+
+
+def _write_script(path: str, body: str) -> None:
+  with open(path, 'w') as f:
+    f.write(f'#!/bin/bash\n{body}\n')
+  os.chmod(path, 0o755)
+
+
+def _stage_wrapped_entrypoint(directory: str) -> str:
+  """Lays out the directory `build_image._wrap_late_bindings` produces.
+
+  Args:
+    directory: Directory to stage into, used as the working directory of the
+      wrapper.
+
+  Returns:
+    A directory to prepend to `PATH`, holding a `python3` shim.
+  """
+  data = os.path.join(os.path.dirname(utils.__file__), 'data')
+  shutil.copy(os.path.join(data, 'wrapped_entrypoint.sh'), directory)
+  # The wrapper imports this module under the name the image stages it as.
+  shutil.copy(utils.__file__, os.path.join(directory, 'vertex_utils.py'))
+
+  _write_script(
+      os.path.join(directory, 'entrypoint.sh'),
+      'exec {} -c {} "$@"'.format(
+          shlex.quote(sys.executable),
+          shlex.quote('import json, sys; print(json.dumps(sys.argv[1:]))'),
+      ),
+  )
+  # The wrapper calls `python3` by name, which need not be the interpreter
+  # running this test nor carry the dependencies of `vertex_utils`.
+  binaries = os.path.join(directory, 'bin')
+  os.makedirs(binaries)
+  _write_script(
+      os.path.join(binaries, 'python3'),
+      f'exec {shlex.quote(sys.executable)} "$@"',
+  )
+  return binaries
 
 
 class UtilsTest(unittest.TestCase):
@@ -85,6 +129,39 @@ export MY_WORKER=cmle-training-workerpool0-ab-0:2222
     """
     with open(t.name) as f:
       self.assertEqual(f.read(), expected.strip())
+
+  def test_wrapped_entrypoint_forwards_arguments(self):
+    if shutil.which('bash') is None:
+      self.skipTest('bash is unavailable')
+    os.environ['CLUSTER_SPEC'] = _CLUSTER_SPEC
+    args = [
+        '--config={"d": 4, "e": 5}',
+        '--path=a path',
+        '--master=' + utils.get_workerpool_address('workerpool0'),
+    ]
+
+    with tempfile.TemporaryDirectory() as directory:
+      binaries = _stage_wrapped_entrypoint(directory)
+      result = subprocess.run(
+          ['bash', 'wrapped_entrypoint.sh', *args],
+          cwd=directory,
+          env={
+              **os.environ,
+              'PATH': os.pathsep.join([binaries, os.environ['PATH']]),
+          },
+          capture_output=True,
+          text=True,
+          check=True,
+      )
+
+    self.assertEqual(
+        json.loads(result.stdout.splitlines()[-1]),
+        [
+            '--config={"d": 4, "e": 5}',
+            '--path=a path',
+            '--master=cmle-training-workerpool0-ab-0:2222',
+        ],
+    )
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
An unquoted trailing `$@` re-splits argument values containing whitespace when `entrypoint.sh` forwards them. This rewrites them as `"$@"` while leaving commands that already forward quoted arguments unchanged.

This was diagnosed and fixed by an LLM.